### PR TITLE
[Feat] 회원가입 및 유저정보 조회, 수정

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -73,7 +73,7 @@ jobs:
             echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
           fi
 
-      - name: Docker compose
+      - name: Deploy new version
         uses: appleboy/ssh-action@master
         with:
           username: ubuntu
@@ -82,7 +82,7 @@ jobs:
           script_stop: true
           script: |
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/live_server:latest
-            sudo docker-compose -f docker-compose-${{env.TARGET_UPSTREAM}}.yml up -d
+            sudo docker-compose -f docker-compose-${{env.TARGET_UPSTREAM}}.yml up -d --remove-orphans
       
       - name: Wait for server to start
         run: sleep 30  # 서버가 시작될 시간을 확보

--- a/src/main/java/com/prototyne/converter/UserConverter.java
+++ b/src/main/java/com/prototyne/converter/UserConverter.java
@@ -5,6 +5,8 @@ import com.prototyne.web.dto.UserDto;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
 @Builder
 public class UserConverter {
@@ -24,7 +26,7 @@ public class UserConverter {
                 .profileUrl(user.getProfileUrl())
                 .tickets(user.getTickets())
                 .gender(user.getGender())
-                .birth(user.getBirth())
+                .birth(user.getBirth().atStartOfDay())
                 .build();
     }
 
@@ -33,7 +35,7 @@ public class UserConverter {
                 .email(kakaoUserInfo.getKakaoAccount().getEmail())
                 .username(kakaoUserInfo.getKakaoAccount().getProfile().getNickName())
                 .gender(userDetailRequest.getGender())
-                .birth(userDetailRequest.getBirth())
+                .birth(LocalDate.from(userDetailRequest.getBirth()))
                 .familyMember(userDetailRequest.getFamilyMember())
                 .build();
     }
@@ -53,7 +55,7 @@ public class UserConverter {
                 .interests(additionalInfo.getInterests())
                 .familyComposition(additionalInfo.getFamilyComposition())
                 .productTypes(additionalInfo.getProductTypes())
-                .smartDevices(additionalInfo.getSmartDevices())
+                .phones(additionalInfo.getPhones())
                 .healthStatus(additionalInfo.getHealthStatus())
                 .build() : new UserDto.AddInfo();
 

--- a/src/main/java/com/prototyne/converter/UserConverter.java
+++ b/src/main/java/com/prototyne/converter/UserConverter.java
@@ -25,4 +25,14 @@ public class UserConverter {
                 .birth(user.getBirth())
                 .build();
     }
+
+    public static User toSignedUser(UserDto.UserInfoResponse kakaoUserInfo, UserDto.UserDetailRequest userDetailRequest){
+        return User.builder()
+                .email(kakaoUserInfo.getKakaoAccount().getEmail())
+                .username(kakaoUserInfo.getKakaoAccount().getProfile().getNickName())
+                .gender(userDetailRequest.getGender())
+                .birth(userDetailRequest.getBirth())
+                .familyMember(userDetailRequest.getFamilyMember())
+                .build();
+    }
 }

--- a/src/main/java/com/prototyne/converter/UserConverter.java
+++ b/src/main/java/com/prototyne/converter/UserConverter.java
@@ -47,7 +47,7 @@ public class UserConverter {
                 .build();
 
         // AddInfo 생성
-        UserDto.AddInfo addInfo = UserDto.AddInfo.builder()
+        UserDto.AddInfo addInfo = (additionalInfo != null) ? UserDto.AddInfo.builder()
                 .occupation(additionalInfo.getOccupation())
                 .income(additionalInfo.getIncome())
                 .interests(additionalInfo.getInterests())
@@ -55,7 +55,7 @@ public class UserConverter {
                 .productTypes(additionalInfo.getProductTypes())
                 .smartDevices(additionalInfo.getSmartDevices())
                 .healthStatus(additionalInfo.getHealthStatus())
-                .build();
+                .build() : new UserDto.AddInfo();
 
         // UserDetailResponse 생성
         return UserDto.UserDetailResponse.builder()

--- a/src/main/java/com/prototyne/converter/UserConverter.java
+++ b/src/main/java/com/prototyne/converter/UserConverter.java
@@ -2,9 +2,11 @@ package com.prototyne.converter;
 
 import com.prototyne.domain.User;
 import com.prototyne.web.dto.UserDto;
+import lombok.Builder;
 import org.springframework.stereotype.Component;
 
 @Component
+@Builder
 public class UserConverter {
     public static User toUser(UserDto.UserInfoResponse userinfo) {
         return User.builder()
@@ -33,6 +35,32 @@ public class UserConverter {
                 .gender(userDetailRequest.getGender())
                 .birth(userDetailRequest.getBirth())
                 .familyMember(userDetailRequest.getFamilyMember())
+                .build();
+    }
+
+    public UserDto.UserDetailResponse toUserDetailResponse(User user, UserDto.AddInfo additionalInfo) {
+        // DetailInfo 생성
+        UserDto.DetailInfo detailInfo = UserDto.DetailInfo.builder()
+                .familyMember(user.getFamilyMember())
+                .gender(user.getGender().toString())
+                .birth(user.getBirth().toString())
+                .build();
+
+        // AddInfo 생성
+        UserDto.AddInfo addInfo = UserDto.AddInfo.builder()
+                .occupation(additionalInfo.getOccupation())
+                .income(additionalInfo.getIncome())
+                .interests(additionalInfo.getInterests())
+                .familyComposition(additionalInfo.getFamilyComposition())
+                .productTypes(additionalInfo.getProductTypes())
+                .smartDevices(additionalInfo.getSmartDevices())
+                .healthStatus(additionalInfo.getHealthStatus())
+                .build();
+
+        // UserDetailResponse 생성
+        return UserDto.UserDetailResponse.builder()
+                .detailInfo(detailInfo)
+                .addInfo(addInfo)
                 .build();
     }
 }

--- a/src/main/java/com/prototyne/domain/ADD_set.java
+++ b/src/main/java/com/prototyne/domain/ADD_set.java
@@ -23,10 +23,10 @@ public class ADD_set extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AddsetTitle title;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 255)
     private String value;
 
-    @OneToMany(mappedBy ="addSet",cascade=CascadeType.ALL)
+    @OneToMany(mappedBy ="addSet",cascade=CascadeType.ALL, orphanRemoval = true)
     private List<Additional> additionalList=new ArrayList<>();
 
 

--- a/src/main/java/com/prototyne/domain/User.java
+++ b/src/main/java/com/prototyne/domain/User.java
@@ -64,7 +64,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Ticket> ticketList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Additional> additionalList = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/com/prototyne/domain/User.java
+++ b/src/main/java/com/prototyne/domain/User.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,7 @@ public class User extends BaseEntity {
     private String profileUrl;
 
     @Column(nullable = false)
-    private LocalDateTime birth;
+    private LocalDate birth;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/prototyne/domain/mapping/Additional.java
+++ b/src/main/java/com/prototyne/domain/mapping/Additional.java
@@ -20,11 +20,11 @@ public class Additional extends BaseEntity {
     @JoinColumn(name="user_id")
     private User user;
 
-    @ManyToOne(fetch=FetchType.LAZY)
+    @ManyToOne(fetch=FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name="set_id")
     private ADD_set addSet;
 
     public Additional(User user, ADD_set addSet) {
-        super();
-    }
-}
+        this.user = user;
+        this.addSet = addSet;
+    }}

--- a/src/main/java/com/prototyne/domain/mapping/Additional.java
+++ b/src/main/java/com/prototyne/domain/mapping/Additional.java
@@ -23,4 +23,8 @@ public class Additional extends BaseEntity {
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="set_id")
     private ADD_set addSet;
+
+    public Additional(User user, ADD_set addSet) {
+        super();
+    }
 }

--- a/src/main/java/com/prototyne/repository/ADD_setRepository.java
+++ b/src/main/java/com/prototyne/repository/ADD_setRepository.java
@@ -1,0 +1,11 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.ADD_set;
+import com.prototyne.domain.enums.AddsetTitle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ADD_setRepository extends JpaRepository<ADD_set, Long> {
+    Optional<ADD_set> findByTitleAndValue(AddsetTitle title, String value);
+}

--- a/src/main/java/com/prototyne/repository/AdditionalRepository.java
+++ b/src/main/java/com/prototyne/repository/AdditionalRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 
 public interface AdditionalRepository extends JpaRepository<Additional, Long> {
     List<Additional> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/prototyne/repository/AdditionalRepository.java
+++ b/src/main/java/com/prototyne/repository/AdditionalRepository.java
@@ -3,9 +3,11 @@ package com.prototyne.repository;
 import com.prototyne.domain.ADD_set;
 import com.prototyne.domain.User;
 import com.prototyne.domain.mapping.Additional;
+import com.prototyne.web.dto.UserDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AdditionalRepository extends JpaRepository<Additional, Long> {
+    List<Additional> findByUserId(Long userId);
 }

--- a/src/main/java/com/prototyne/repository/AdditionalRepository.java
+++ b/src/main/java/com/prototyne/repository/AdditionalRepository.java
@@ -1,0 +1,11 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.ADD_set;
+import com.prototyne.domain.User;
+import com.prototyne.domain.mapping.Additional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AdditionalRepository extends JpaRepository<Additional, Long> {
+}

--- a/src/main/java/com/prototyne/service/LoginService/KakaoServiceImpl.java
+++ b/src/main/java/com/prototyne/service/LoginService/KakaoServiceImpl.java
@@ -83,14 +83,4 @@ public class KakaoServiceImpl implements KakaoService {
         User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
         return UserConverter.toUserInfoDto(user);
     }
-
-    public void signIn(String token, UserDto.UserDetailRequest request) {
-        Long id = jwtManager.validateJwt(token);
-        User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
-        user.setFamilyMember(request.getFamilyMember());
-        user.setGender(request.getGender());
-        user.setBirth(request.getBirth());
-        user.setSignupComplete(true);
-        userRepository.save(user);
-    }
 }

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupService.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupService.java
@@ -8,10 +8,12 @@ import com.prototyne.domain.mapping.Additional;
 import com.prototyne.repository.UserRepository;
 import com.prototyne.web.dto.UserDto;
 
+import java.util.List;
+
 public interface UserSignupService {
-    void saveAddSetInfo(User user, AddsetTitle title, String value);
+    void saveAddSetInfo(User user, AddsetTitle title, List<String> values);
 
     void saveAdditionalInfo(User user, UserDto.UserAddInfoRequest request);
 
-    User signup(String aouthToken, UserDto.UserDetailRequest request, UserDto.UserAddInfoRequest addInfoRequest);
+    UserDto.UserSignUpResponse signup(String aouthToken, UserDto.UserDetailRequest request, UserDto.UserAddInfoRequest addInfoRequest);
 }

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupService.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupService.java
@@ -1,0 +1,17 @@
+package com.prototyne.service.SignupService;
+
+import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.domain.ADD_set;
+import com.prototyne.domain.User;
+import com.prototyne.domain.enums.AddsetTitle;
+import com.prototyne.domain.mapping.Additional;
+import com.prototyne.repository.UserRepository;
+import com.prototyne.web.dto.UserDto;
+
+public interface UserSignupService {
+    void saveAddSetInfo(User user, AddsetTitle title, String value);
+
+    void saveAdditionalInfo(User user, UserDto.UserAddInfoRequest request);
+
+    User signup(String aouthToken, UserDto.UserDetailRequest request, UserDto.UserAddInfoRequest addInfoRequest);
+}

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -30,16 +30,6 @@ public class UserSignupServiceImpl implements UserSignupService {
     @Lazy
     private final KakaoServiceImpl kakaoService;
     private final JwtManager jwtManager;
-
-    public void signIn(String token, UserDto.UserDetailRequest request) {
-        Long id = jwtManager.validateJwt(token);
-        User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
-        user.setFamilyMember(request.getFamilyMember());
-        user.setGender(request.getGender());
-        user.setBirth(request.getBirth());
-        user.setSignupComplete(true);
-        userRepository.save(user);
-    }
     @Override
     public User signup(String aouthToken,
                        UserDto.UserDetailRequest userDetailRequest,

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -1,0 +1,85 @@
+package com.prototyne.service.SignupService;
+
+import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.converter.UserConverter;
+import com.prototyne.domain.ADD_set;
+import com.prototyne.domain.User;
+import com.prototyne.domain.enums.AddsetTitle;
+import com.prototyne.domain.mapping.Additional;
+import com.prototyne.repository.AdditionalRepository;
+import com.prototyne.repository.UserRepository;
+import com.prototyne.service.LoginService.JwtManager;
+import com.prototyne.service.LoginService.KakaoService;
+import com.prototyne.service.LoginService.KakaoServiceImpl;
+import com.prototyne.web.dto.UserDto;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class UserSignupServiceImpl implements UserSignupService {
+    private final UserRepository userRepository;
+    private final AdditionalRepository additionalRepository;
+    @Lazy
+    private final KakaoServiceImpl kakaoService;
+    private final JwtManager jwtManager;
+
+    public void signIn(String token, UserDto.UserDetailRequest request) {
+        Long id = jwtManager.validateJwt(token);
+        User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
+        user.setFamilyMember(request.getFamilyMember());
+        user.setGender(request.getGender());
+        user.setBirth(request.getBirth());
+        user.setSignupComplete(true);
+        userRepository.save(user);
+    }
+    @Override
+    public User signup(String aouthToken,
+                       UserDto.UserDetailRequest userDetailRequest,
+                       UserDto.UserAddInfoRequest addInfoRequest){
+        UserDto.UserInfoResponse kakaoUserInfo = kakaoService.getKakaoInfo(aouthToken);
+        // 카카오 이메일로 기존 회원이 존재하는지 여부 조회
+        User existingUser = userRepository.findByEmail(kakaoUserInfo.getKakaoAccount().getEmail());
+
+        if(existingUser != null) {
+            throw new RuntimeException("해당 이메일로 이미 가입한 회원이 존재합니다.");
+        }
+
+        User newUser = UserConverter.toSignedUser(kakaoUserInfo, userDetailRequest);
+        userRepository.save(newUser);
+
+        // 추가 정보 저장
+        saveAdditionalInfo(newUser, addInfoRequest);
+        return newUser;
+    }
+
+    @Override
+    public void saveAddSetInfo(User user, AddsetTitle title, String value){
+        if (value != null && !value.isEmpty()) {
+            ADD_set addSet = ADD_set.builder()
+                    .title(title)
+                    .value(value)
+                    .build();
+            additionalRepository.save(new Additional(user, addSet));
+        }
+    }
+
+    @Override
+    public void saveAdditionalInfo(User user, UserDto.UserAddInfoRequest request) {
+        saveAddSetInfo(user, AddsetTitle.직업, request.getOccupation());
+        saveAddSetInfo(user, AddsetTitle.소득수준, String.valueOf(request.getIncome()));
+        saveAddSetInfo(user, AddsetTitle.관심사, String.join(",", request.getInterests()));
+        saveAddSetInfo(user, AddsetTitle.가족구성, request.getFamilyComposition());
+        saveAddSetInfo(user, AddsetTitle.관심제품유형, String.join(",", request.getProductTypes()));
+        saveAddSetInfo(user, AddsetTitle.스마트기기_기종, String.join(",", request.getSmartDevices()));
+        saveAddSetInfo(user, AddsetTitle.건강상태, String.valueOf(request.getHealthStatus()));
+    }
+
+}

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -81,7 +81,7 @@ public class UserSignupServiceImpl implements UserSignupService {
         saveAddSetInfo(user, AddsetTitle.관심사, request.getInterests());
         saveAddSetInfo(user, AddsetTitle.가족구성, Collections.singletonList(request.getFamilyComposition()));
         saveAddSetInfo(user, AddsetTitle.관심제품유형, request.getProductTypes());
-        saveAddSetInfo(user, AddsetTitle.스마트기기_기종, request.getSmartDevices());
+        saveAddSetInfo(user, AddsetTitle.스마트기기_기종, request.getPhones());
         saveAddSetInfo(user, AddsetTitle.건강상태, Collections.singletonList(String.valueOf(request.getHealthStatus())));
     }
 

--- a/src/main/java/com/prototyne/service/UserService/UserDetailService.java
+++ b/src/main/java/com/prototyne/service/UserService/UserDetailService.java
@@ -2,9 +2,14 @@ package com.prototyne.service.UserService;
 
 import com.prototyne.domain.User;
 import com.prototyne.web.dto.UserDto;
+import jakarta.transaction.Transactional;
 
 import java.nio.file.attribute.UserPrincipalNotFoundException;
 
 public interface UserDetailService {
     UserDto.UserDetailResponse getUserDetail(String accessToken) throws UserPrincipalNotFoundException;
+
+    UserDto.DetailInfo updateBasicInfo(String accessToken, UserDto.DetailInfo detailInfo) throws UserPrincipalNotFoundException;
+
+    UserDto.AddInfo updateAddInfo(String accessToken, UserDto.AddInfo addInfo) throws UserPrincipalNotFoundException;
 }

--- a/src/main/java/com/prototyne/service/UserService/UserDetailService.java
+++ b/src/main/java/com/prototyne/service/UserService/UserDetailService.java
@@ -1,0 +1,10 @@
+package com.prototyne.service.UserService;
+
+import com.prototyne.domain.User;
+import com.prototyne.web.dto.UserDto;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
+
+public interface UserDetailService {
+    UserDto.UserDetailResponse getUserDetail(String accessToken) throws UserPrincipalNotFoundException;
+}

--- a/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
+++ b/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
@@ -1,0 +1,79 @@
+package com.prototyne.service.UserService;
+
+import com.prototyne.converter.UserConverter;
+import com.prototyne.domain.User;
+import com.prototyne.domain.mapping.Additional;
+import com.prototyne.repository.AdditionalRepository;
+import com.prototyne.repository.UserRepository;
+import com.prototyne.service.LoginService.JwtManager;
+import com.prototyne.web.dto.UserDto;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class UserDetailServiceImpl implements UserDetailService {
+
+    private final UserRepository userRepository;
+    private final AdditionalRepository additionalRepository;
+    private final JwtManager jwtManager;
+    private final UserConverter userConverter;
+
+
+    @Override
+    public UserDto.UserDetailResponse getUserDetail(String accessToken) throws UserPrincipalNotFoundException {
+        Long userId = jwtManager.validateJwt(accessToken);
+
+        // 추출한 사용자 ID를 사용하여 사용자 정보를 조회합니다.
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserPrincipalNotFoundException(userId + "에 해당하는 회원이 없습니다."));
+
+        List<Additional> additionalInfo = (List<Additional>) additionalRepository.findByUserId(userId);
+        if(additionalInfo.isEmpty()){
+            throw new UserPrincipalNotFoundException(userId + "에 해당하는 추가 정보가 없습니다.");
+        }
+
+        UserDto.AddInfo convertedAddInfo = convertToAddInfo(additionalInfo);
+
+        return userConverter.toUserDetailResponse(user, convertedAddInfo);
+
+    }
+
+    private UserDto.AddInfo convertToAddInfo(List<Additional> additionalInfo) {
+        UserDto.AddInfo addInfo = new UserDto.AddInfo();
+        for (Additional additional : additionalInfo) {
+            switch (additional.getAddSet().getTitle()) {
+                case 직업:
+                    addInfo.setOccupation(additional.getAddSet().getValue());
+                    break;
+                case 소득수준:
+                    addInfo.setIncome(Integer.parseInt(additional.getAddSet().getValue()));
+                    break;
+                case 관심사:
+                    addInfo.setInterests(Arrays.asList(additional.getAddSet().getValue().split(",")));
+                    break;
+                case 가족구성:
+                    addInfo.setFamilyComposition(additional.getAddSet().getValue());
+                    break;
+                case 관심제품유형:
+                    addInfo.setProductTypes(Arrays.asList(additional.getAddSet().getValue().split(",")));
+                    break;
+                case 스마트기기_기종:
+                    addInfo.setSmartDevices(Arrays.asList(additional.getAddSet().getValue().split(",")));
+                    break;
+                case 건강상태:
+                    addInfo.setHealthStatus(Integer.parseInt(additional.getAddSet().getValue()));
+                    break;
+            }
+        }
+        return addInfo;
+    }
+
+
+}

--- a/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
+++ b/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.attribute.UserPrincipalNotFoundException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -42,9 +43,6 @@ public class UserDetailServiceImpl implements UserDetailService {
                 .orElseThrow(() -> new UserPrincipalNotFoundException(userId + "에 해당하는 회원이 없습니다."));
 
         List<Additional> additionalInfo = additionalRepository.findByUserId(userId);
-        if(additionalInfo.isEmpty()){
-            throw new UserPrincipalNotFoundException(userId + "에 해당하는 추가 정보가 없습니다.");
-        }
 
         UserDto.AddInfo convertedAddInfo = convertToAddInfo(additionalInfo);
 
@@ -61,25 +59,25 @@ public class UserDetailServiceImpl implements UserDetailService {
 
             switch (additional.getAddSet().getTitle()) {
                 case 직업:
-                    addInfo.setOccupation(valueList.get(0));  // 직업은 단일값
+                    addInfo.setOccupation(valueList.isEmpty()? null : valueList.get(0));  // 직업은 단일값
                     break;
                 case 소득수준:
-                    addInfo.setIncome(Integer.parseInt(valueList.get(0)));  // 소득수준은 단일값
+                    addInfo.setIncome(valueList.isEmpty()? 0 : Integer.parseInt(valueList.get(0)));  // 소득수준은 단일값
                     break;
                 case 관심사:
                     addInfo.setInterests(valueList);  // 관심사는 리스트
                     break;
                 case 가족구성:
-                    addInfo.setFamilyComposition(valueList.get(0));  // 가족구성은 단일값
+                    addInfo.setFamilyComposition(valueList.isEmpty()? null : valueList.get(0));  // 가족구성은 단일값
                     break;
                 case 관심제품유형:
                     addInfo.setProductTypes(valueList);  // 관심제품유형은 리스트
                     break;
                 case 스마트기기_기종:
-                    addInfo.setSmartDevices(valueList);  // 스마트기기_기종은 리스트
+                    addInfo.setPhones(valueList);  // 스마트기기_기종은 리스트
                     break;
                 case 건강상태:
-                    addInfo.setHealthStatus(Integer.parseInt(valueList.get(0)));  // 건강상태는 단일값
+                    addInfo.setHealthStatus(valueList.isEmpty()? null : Integer.parseInt(valueList.get(0)));  // 건강상태는 단일값
                     break;
             }
         }
@@ -98,7 +96,7 @@ public class UserDetailServiceImpl implements UserDetailService {
         // 업데이트할 정보를 설정합니다.
         user.setFamilyMember(detailInfo.getFamilyMember());
         user.setGender(Gender.valueOf(detailInfo.getGender()));
-        user.setBirth(LocalDateTime.parse(detailInfo.getBirth()));
+        user.setBirth(LocalDate.parse(detailInfo.getBirth()));
 
         userRepository.save(user);
 
@@ -131,8 +129,8 @@ public class UserDetailServiceImpl implements UserDetailService {
         if (addInfo.getProductTypes() != null) {
             saveAddSetInfo(user, AddsetTitle.관심제품유형, String.join(",", addInfo.getProductTypes()));
         }
-        if (addInfo.getSmartDevices() != null) {
-            saveAddSetInfo(user, AddsetTitle.스마트기기_기종, String.join(",", addInfo.getSmartDevices()));
+        if (addInfo.getPhones() != null) {
+            saveAddSetInfo(user, AddsetTitle.스마트기기_기종, String.join(",", addInfo.getPhones()));
         }
         if (addInfo.getHealthStatus() > 0) {
             saveAddSetInfo(user, AddsetTitle.건강상태, String.valueOf(addInfo.getHealthStatus()));

--- a/src/main/java/com/prototyne/web/controller/LoginController.java
+++ b/src/main/java/com/prototyne/web/controller/LoginController.java
@@ -49,4 +49,5 @@ public class LoginController {
         String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
         return ApiResponse.onSuccess(kakaoService.getUserInfo(aouthtoken));
     }
+
 }

--- a/src/main/java/com/prototyne/web/controller/LoginController.java
+++ b/src/main/java/com/prototyne/web/controller/LoginController.java
@@ -6,20 +6,22 @@ import com.prototyne.web.dto.UserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/oauth2")
+@Tag(name = "${swagger.tag.auth}")
 public class LoginController {
+
     private final KakaoServiceImpl kakaoService;
 
-    @Tag(name = "${swagger.tag.auth}")
     @GetMapping("/login")
     @Operation(summary = "로그인 API",
             description = "Access Token 응답",
@@ -29,15 +31,14 @@ public class LoginController {
         return ApiResponse.onSuccess(accessToken);
     }
 
-
-    @Tag(name = "${swagger.tag.auth}")
-    @GetMapping("/user")
-    @Operation(summary = "사용자 정보 조회 API - 인증 필요",
-            description = "사용자 정보 조회 API - 인증 필요",
-            security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<UserDto.UserRequest> userInfo(HttpServletRequest token) {
-        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
-        return ApiResponse.onSuccess(kakaoService.getUserInfo(aouthtoken));
-    }
+//
+//    @GetMapping("/user")
+//    @Operation(summary = "사용자 정보 조회 API - 인증 필요",
+//            description = "사용자 정보 조회 API - 인증 필요",
+//            security = {@SecurityRequirement(name = "session-token")})
+//    public ApiResponse<UserDto.UserRequest> userInfo(HttpServletRequest token) {
+//        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
+//        return ApiResponse.onSuccess(kakaoService.getUserInfo(aouthtoken));
+//    }
 
 }

--- a/src/main/java/com/prototyne/web/controller/LoginController.java
+++ b/src/main/java/com/prototyne/web/controller/LoginController.java
@@ -29,18 +29,8 @@ public class LoginController {
         return ApiResponse.onSuccess(accessToken);
     }
 
-//    @Tag(name = "${swagger.tag.auth}")
-//    @PostMapping("/signup")
-//    @Operation(summary = "회원가입 API - 인증 필요",
-//            description = "회원가입 API - 인증 필요",
-//            security = {@SecurityRequirement(name = "session-token")})
-//    public ApiResponse<String> userInfo(HttpServletRequest token, @RequestBody @Valid UserDto.UserDetailRequest request) {
-//        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
-//        kakaoService.signIn(aouthtoken, request);
-//        return ApiResponse.onSuccess("회원가입 완료");
-//    }
 
-    @Tag(name = "${swagger.tag.my}")
+    @Tag(name = "${swagger.tag.auth}")
     @GetMapping("/user")
     @Operation(summary = "사용자 정보 조회 API - 인증 필요",
             description = "사용자 정보 조회 API - 인증 필요",

--- a/src/main/java/com/prototyne/web/controller/LoginController.java
+++ b/src/main/java/com/prototyne/web/controller/LoginController.java
@@ -29,16 +29,16 @@ public class LoginController {
         return ApiResponse.onSuccess(accessToken);
     }
 
-    @Tag(name = "${swagger.tag.auth}")
-    @PostMapping("/signup")
-    @Operation(summary = "회원가입 API - 인증 필요",
-            description = "회원가입 API - 인증 필요",
-            security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<String> userInfo(HttpServletRequest token, @RequestBody @Valid UserDto.UserDetailRequest request) {
-        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
-        kakaoService.signIn(aouthtoken, request);
-        return ApiResponse.onSuccess("회원가입 완료");
-    }
+//    @Tag(name = "${swagger.tag.auth}")
+//    @PostMapping("/signup")
+//    @Operation(summary = "회원가입 API - 인증 필요",
+//            description = "회원가입 API - 인증 필요",
+//            security = {@SecurityRequirement(name = "session-token")})
+//    public ApiResponse<String> userInfo(HttpServletRequest token, @RequestBody @Valid UserDto.UserDetailRequest request) {
+//        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
+//        kakaoService.signIn(aouthtoken, request);
+//        return ApiResponse.onSuccess("회원가입 완료");
+//    }
 
     @Tag(name = "${swagger.tag.my}")
     @GetMapping("/user")

--- a/src/main/java/com/prototyne/web/controller/MyController.java
+++ b/src/main/java/com/prototyne/web/controller/MyController.java
@@ -1,0 +1,40 @@
+package com.prototyne.web.controller;
+
+import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.service.UserService.UserDetailServiceImpl;
+import com.prototyne.web.dto.UserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my")
+@Tag(name = "02. 내 정보 - 기본", description = "유저 정보 관련 API")
+public class MyController {
+
+    private final UserDetailServiceImpl userDetailService;
+
+    @Tag(name = "${swagger.tag.auth}")
+    @GetMapping("/detail")
+    @Operation(summary = "유저 정보 조회 API - 인증 필요",
+            description = "유저 정보 조회 API - 인증 필요",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<UserDto.UserDetailResponse> getUserDetail(HttpServletRequest request) throws Exception {
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+        log.info("JWT Token: {}", accessToken);
+        UserDto.UserDetailResponse userDetailResponse = userDetailService.getUserDetail(accessToken);
+        return ApiResponse.onSuccess(userDetailResponse);
+    }
+
+}

--- a/src/main/java/com/prototyne/web/controller/MyController.java
+++ b/src/main/java/com/prototyne/web/controller/MyController.java
@@ -23,7 +23,7 @@ public class MyController {
 
     private final UserDetailServiceImpl userDetailService;
 
-    @Tag(name = "${swagger.tag.auth}")
+    @Tag(name = "${swagger.tag.my}")
     @GetMapping("/detail")
     @Operation(summary = "유저 정보 조회 API - 인증 필요",
             description = "유저 정보 조회 API - 인증 필요",

--- a/src/main/java/com/prototyne/web/controller/MyController.java
+++ b/src/main/java/com/prototyne/web/controller/MyController.java
@@ -18,45 +18,57 @@ import java.nio.file.attribute.UserPrincipalNotFoundException;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/my")
-@Tag(name = "02. 내 정보 - 기본", description = "유저 정보 관련 API")
+@Tag(name = "${swagger.tag.my}")
 public class MyController {
 
     private final UserDetailServiceImpl userDetailService;
 
-    @Tag(name = "${swagger.tag.my}")
     @GetMapping("/detail")
     @Operation(summary = "유저 정보 조회 API - 인증 필요",
             description = "유저 정보 조회 API - 인증 필요",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<UserDto.UserDetailResponse> getUserDetail(HttpServletRequest request) throws Exception {
         String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
-        log.info("JWT Token: {}", accessToken);
         UserDto.UserDetailResponse userDetailResponse = userDetailService.getUserDetail(accessToken);
         return ApiResponse.onSuccess(userDetailResponse);
     }
 
     @PatchMapping("/basicInfo")
     @Operation(summary = "필수 정보 수정 API - 인증 필요",
-            description = "유저의 필수 정보를 수정합니다.",
+            description = """
+                    유저의 필수 정보를 수정합니다.
+                   \s
+                    [body] \s
+                    *familymember: 가족 구성원 수(int), \s
+                    *gender: "MALE" | "FEMALE", \s
+                    *birth: "YYYY-MM-DD"
+                   \s""",
             security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<UserDto.DetailInfo> updateDetailInfo(HttpServletRequest request,
-                                                @RequestBody @Valid UserDto.DetailInfo detailInfo) throws UserPrincipalNotFoundException {
+    public ApiResponse<UserDto.DetailInfo> updateDetailInfo(HttpServletRequest request, @RequestBody @Valid UserDto.DetailInfo detailInfo) throws UserPrincipalNotFoundException {
         String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
-        log.info("JWT Token: {}", accessToken);
-
         return ApiResponse.onSuccess(userDetailService.updateBasicInfo(accessToken, detailInfo));
 
     }
 
     @PatchMapping("/addInfo")
     @Operation(summary = "추가 정보 수정 API - 인증 필요",
-            description = "유저의 추가 정보를 수정합니다.",
+            description = """
+                    유저의 추가 정보를 수정합니다. - 수정 필요한 key-value 만 입력
+                    \s
+                    [body] \s
+                    occupation: 직업(string) - | "STUDENT" | "OFFICE" | "PROFESSIONAL" | "SELFEMPLOYED" | "OTHER", \s
+                    income: 수입(int) - | 2000 | 4000 | 6000 | 8000 | 9999, \s
+                    interests: 관심사(string[]) - | 1 | "COUPLE" | "COUPLE&CHILDREN" | "PARENTS&CHILDREN" | "EXTENDFAMILY", \s
+                    familyComposition: 가족 구성(string), - | 1 | "COUPLE" | "COUPLE&CHILDREN" | "PARENTS&CHILDREN" | "EXTENDFAMILY" \s
+                    productTypes: 관심 상품(string[]) - | "ELECTRONIC" | "FASHION&BEAUTY" | "FOOD" | "HOUSEHOLD" | "HEALTH", \s
+                    phones: 휴대폰 종류(string[]) - | "SMARTPHONE1" | "SMARTPHONE2" | "SMARTPHONE9" | "TABLET" | "SMARTWATCH", \s
+                    healthStatus: 건강 상태(int) - | 1 | 2 | 3 | 4 | 5
+                    \s
+                   \s""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<UserDto.AddInfo> updateAddInfo(HttpServletRequest request,
                                          @RequestBody @Valid UserDto.AddInfo addInfo) throws UserPrincipalNotFoundException {
         String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
-        log.info("JWT Token: {}", accessToken);
-
         return ApiResponse.onSuccess(userDetailService.updateAddInfo(accessToken, addInfo));
     }
 

--- a/src/main/java/com/prototyne/web/controller/MyController.java
+++ b/src/main/java/com/prototyne/web/controller/MyController.java
@@ -1,20 +1,18 @@
 package com.prototyne.web.controller;
 
 import com.prototyne.apiPayload.ApiResponse;
-import com.prototyne.apiPayload.code.status.ErrorStatus;
 import com.prototyne.service.UserService.UserDetailServiceImpl;
 import com.prototyne.web.dto.UserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
 
 @Slf4j
 @RestController
@@ -35,6 +33,31 @@ public class MyController {
         log.info("JWT Token: {}", accessToken);
         UserDto.UserDetailResponse userDetailResponse = userDetailService.getUserDetail(accessToken);
         return ApiResponse.onSuccess(userDetailResponse);
+    }
+
+    @PatchMapping("/basicInfo")
+    @Operation(summary = "필수 정보 수정 API - 인증 필요",
+            description = "유저의 필수 정보를 수정합니다.",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<UserDto.DetailInfo> updateDetailInfo(HttpServletRequest request,
+                                                @RequestBody @Valid UserDto.DetailInfo detailInfo) throws UserPrincipalNotFoundException {
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+        log.info("JWT Token: {}", accessToken);
+
+        return ApiResponse.onSuccess(userDetailService.updateBasicInfo(accessToken, detailInfo));
+
+    }
+
+    @PatchMapping("/addInfo")
+    @Operation(summary = "추가 정보 수정 API - 인증 필요",
+            description = "유저의 추가 정보를 수정합니다.",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<UserDto.AddInfo> updateAddInfo(HttpServletRequest request,
+                                         @RequestBody @Valid UserDto.AddInfo addInfo) throws UserPrincipalNotFoundException {
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+        log.info("JWT Token: {}", accessToken);
+
+        return ApiResponse.onSuccess(userDetailService.updateAddInfo(accessToken, addInfo));
     }
 
 }

--- a/src/main/java/com/prototyne/web/controller/SignupController.java
+++ b/src/main/java/com/prototyne/web/controller/SignupController.java
@@ -1,0 +1,42 @@
+package com.prototyne.web.controller;
+
+import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.domain.User;
+import com.prototyne.service.LoginService.KakaoServiceImpl;
+import com.prototyne.service.SignupService.UserSignupService;
+import com.prototyne.service.SignupService.UserSignupServiceImpl;
+import com.prototyne.web.dto.UserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth2")
+public class SignupController {
+    private final UserSignupServiceImpl signupService;
+
+    @Tag(name = "${swagger.tag.auth}")
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입 API - 인증 필요",
+            description = "회원가입 API - 인증 필요",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<UserDto.UserSignUpResponse> userInfo(HttpServletRequest token,
+                                        @RequestBody @Valid UserDto.UserSignUpRequest signUpRequest) {
+
+        String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
+        User user = signupService.signup(aouthtoken, signUpRequest.getDetailRequest(), signUpRequest.getAddInfoRequest());
+
+        UserDto.UserSignUpResponse signUpResponse = new UserDto.UserSignUpResponse(user.getId(), aouthtoken);
+        return ApiResponse.onSuccess(signUpResponse);
+    }
+}

--- a/src/main/java/com/prototyne/web/controller/SignupController.java
+++ b/src/main/java/com/prototyne/web/controller/SignupController.java
@@ -30,13 +30,11 @@ public class SignupController {
     @Operation(summary = "회원가입 API - 인증 필요",
             description = "회원가입 API - 인증 필요",
             security = {@SecurityRequirement(name = "session-token")})
-    public ApiResponse<UserDto.UserSignUpResponse> userInfo(HttpServletRequest token,
+    public ApiResponse<UserDto.UserSignUpResponse> signup(HttpServletRequest token,
                                         @RequestBody @Valid UserDto.UserSignUpRequest signUpRequest) {
 
         String aouthtoken = token.getHeader("Authorization").replace("Bearer ", "");
-        User user = signupService.signup(aouthtoken, signUpRequest.getDetailRequest(), signUpRequest.getAddInfoRequest());
+        return ApiResponse.onSuccess(signupService.signup(aouthtoken, signUpRequest.getDetailRequest(), signUpRequest.getAddInfoRequest()));
 
-        UserDto.UserSignUpResponse signUpResponse = new UserDto.UserSignUpResponse(user.getId(), aouthtoken);
-        return ApiResponse.onSuccess(signUpResponse);
     }
 }

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -42,17 +42,17 @@ public class UserDto {
         private final List<String> interests;
         private final String familyComposition;
         private final List<String> productTypes;
-        private final List<String> smartDevices;
+        private final List<String> phones;
         private final Integer healthStatus;
 
         public UserAddInfoRequest(String occupation, Integer income, List<String> interests, String familyComposition,
-                                     List<String> productTypes, List<String> smartDevices, Integer healthStatus){
+                                     List<String> productTypes, List<String> phones, Integer healthStatus){
             this.occupation = occupation;
             this.income = income;
             this.interests = interests;
             this.familyComposition = familyComposition;
             this.productTypes = productTypes;
-            this.smartDevices = smartDevices;
+            this.phones = phones;
             this.healthStatus = healthStatus;
         }
     }

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -3,13 +3,11 @@ package com.prototyne.web.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.prototyne.domain.enums.Gender;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 
 public class UserDto {
     @Builder
@@ -35,6 +33,29 @@ public class UserDto {
             this.Birth = birth;
         }
     }
+
+    @Getter
+    public static class UserAddInfoRequest {
+        private final String occupation;
+        private final Integer income;
+        private final List<String> interests;
+        private final String familyComposition;
+        private final List<String> productTypes;
+        private final List<String> smartDevices;
+        private final Integer healthStatus;
+
+        public UserAddInfoRequest(String occupation, Integer income, List<String> interests, String familyComposition,
+                                     List<String> productTypes, List<String> smartDevices, Integer healthStatus){
+            this.occupation = occupation;
+            this.income = income;
+            this.interests = interests;
+            this.familyComposition = familyComposition;
+            this.productTypes = productTypes;
+            this.smartDevices = smartDevices;
+            this.healthStatus = healthStatus;
+        }
+    }
+
 
     @Getter
     @Setter
@@ -110,4 +131,20 @@ public class UserDto {
             }
         }
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UserSignUpRequest {
+        private UserDto.UserDetailRequest detailRequest;
+        private UserDto.UserAddInfoRequest addInfoRequest;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class UserSignUpResponse {
+        private final Long userId;
+        private final String token;
+    }
+
 }

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -174,7 +174,7 @@ public class UserDto {
         private List<String> interests;
         private String familyComposition;
         private List<String> productTypes;
-        private List<String> smartDevices;
+        private List<String> phones;
         private int healthStatus;
 
     }

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -2,6 +2,7 @@ package com.prototyne.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.prototyne.domain.User;
 import com.prototyne.domain.enums.Gender;
 import lombok.*;
 
@@ -145,6 +146,37 @@ public class UserDto {
     public static class UserSignUpResponse {
         private final Long userId;
         private final String token;
+    }
+
+    @Data
+    @Builder
+    public static class UserDetailResponse {
+        private DetailInfo detailInfo;
+        private AddInfo addInfo;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class DetailInfo {
+        private int familyMember;
+        private String gender;
+        private String birth;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AddInfo {
+        private String occupation;
+        private int income;
+        private List<String> interests;
+        private String familyComposition;
+        private List<String> productTypes;
+        private List<String> smartDevices;
+        private int healthStatus;
+
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
#21 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ PR 내용
feat: 회원 가입 API 구현
feat: 유저 정보 조회, 수정 API 구현
fix: 추가 정보 db에 저장 안되는 현상 해결
fix: 추가 정보 전자기기 필드명 phones로 수정
fix: (코드 리뷰 반영) 유저 birth 형식 LocalDate(yyyy-mm-dd)로 변형, 전자기기 기종 필드명 'phone'으로 통일

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
### 1. 회원 가입 API test (POST `/oauth2/signup`)
- 헤더에 소셜 로그인으로 발급받은 토큰 값을 넣어 회원가입 처리를 하면, response로 jwt 토큰을 발급받는다.
- 해당 API 이후 헤더에 들어갈 토큰은 회원가입 때 발급받은 jwt 토큰 값

- [x]  birth 필드를 LocalDate("yyyy-mm-dd") 형식으로 변형하여 수정사항 반영
- [x] 전자기기 기종 필드명 'phones'로 통일

![image](https://github.com/user-attachments/assets/7b3817d1-1073-4b02-ab49-1779b0a79a33)


### 2. 유저 정보 조회 API test (GET `/my/detail`)
- 헤더에 jwt 토큰 값을 넣어 사용자 인증을 한다.
- 필수 정보 및 추가 정보를 한번에 조회 하는 API
![image](https://github.com/user-attachments/assets/193f6626-4a5a-4189-9171-9c4fdd96ee51)

### 3. 필수 정보 수정 API test (PATCH `/my/basicInfo`)
- 헤더에 jwt 토큰 값을 넣어 사용자 인증을 한다. 
- 필수 정보를 수정하는 API
![image](https://github.com/user-attachments/assets/52a68f96-0569-4d21-bfff-2047709f33fc)

### 4. 추가 정보 수정 API test (PATCH `/my/addInfo`)
- 헤더에 jwt 토큰 값을 넣어 사용자 인증을 한다. 
- 추가 정보를 수정하는 API
![image](https://github.com/user-attachments/assets/06f41313-5ac8-4567-a686-0c96dcdf3dc5)