### PR TITLE
[bug] 회원가입, 추가 정보 수정 관련

### DIFF
--- a/src/main/java/com/prototyne/converter/UserConverter.java
+++ b/src/main/java/com/prototyne/converter/UserConverter.java
@@ -27,17 +27,29 @@ public class UserConverter {
                 .profileUrl(user.getProfileUrl())
                 .tickets(user.getTickets())
                 .gender(user.getGender())
-                .birth(user.getBirth().atStartOfDay())
+                .birth(user.getBirth())
                 .build();
     }
 
-    public static User toSignedUser(UserDto.UserInfoResponse kakaoUserInfo, UserDto.UserDetailRequest userDetailRequest){
+    public static User toSignedUser(User user, UserDto.UserDetailRequest userDetailRequest){
         return User.builder()
-                .email(kakaoUserInfo.getKakaoAccount().getEmail())
-                .username(kakaoUserInfo.getKakaoAccount().getProfile().getNickName())
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .profileUrl(user.getProfileUrl())
+                .signupComplete(true)
+                .tickets(0)
                 .gender(userDetailRequest.getGender())
                 .birth(LocalDate.from(userDetailRequest.getBirth()))
                 .familyMember(userDetailRequest.getFamilyMember())
+                .build();
+    }
+
+    public static DeliveryDto toDeliveryDto(User user) {
+        return DeliveryDto.builder()
+                .deliveryName(user.getDeliveryName())
+                .deliveryPhone(user.getDeliveryPhone())
+                .deliveryAddress(user.getDeliveryAddress())
                 .build();
     }
 
@@ -64,14 +76,6 @@ public class UserConverter {
         return UserDto.UserDetailResponse.builder()
                 .detailInfo(detailInfo)
                 .addInfo(addInfo)
-                .build();
-    }
-
-    public static DeliveryDto toDeliveryDto(User user) {
-        return DeliveryDto.builder()
-                .deliveryName(user.getDeliveryName())
-                .deliveryPhone(user.getDeliveryPhone())
-                .deliveryAddress(user.getDeliveryAddress())
                 .build();
     }
 }

--- a/src/main/java/com/prototyne/domain/ADD_set.java
+++ b/src/main/java/com/prototyne/domain/ADD_set.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -23,7 +24,7 @@ public class ADD_set extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AddsetTitle title;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false, length = 1000)
     private String value;
 
     @OneToMany(mappedBy ="addSet",cascade=CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/prototyne/domain/User.java
+++ b/src/main/java/com/prototyne/domain/User.java
@@ -5,6 +5,7 @@ import com.prototyne.domain.enums.Gender;
 import com.prototyne.domain.mapping.Additional;
 import com.prototyne.domain.mapping.Heart;
 import com.prototyne.web.dto.DeliveryDto;
+import com.prototyne.web.dto.UserDto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -12,7 +13,6 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,5 +89,11 @@ public class User extends BaseEntity {
         System.out.println("deliveryDto.getDeliveryPhone() = " + deliveryDto.getDeliveryPhone());
         this.deliveryPhone = deliveryDto.getDeliveryPhone();
         this.deliveryAddress = deliveryDto.getDeliveryAddress();
+    }
+
+    public void setDetail(UserDto.UserDetailRequest userDetailRequest){
+        this.birth = LocalDate.from(userDetailRequest.getBirth());
+        this.familyMember = userDetailRequest.getFamilyMember();
+        this.gender = userDetailRequest.getGender();
     }
 }

--- a/src/main/java/com/prototyne/domain/mapping/Additional.java
+++ b/src/main/java/com/prototyne/domain/mapping/Additional.java
@@ -27,4 +27,5 @@ public class Additional extends BaseEntity {
     public Additional(User user, ADD_set addSet) {
         this.user = user;
         this.addSet = addSet;
-    }}
+    }
+}

--- a/src/main/java/com/prototyne/repository/AdditionalRepository.java
+++ b/src/main/java/com/prototyne/repository/AdditionalRepository.java
@@ -2,13 +2,17 @@ package com.prototyne.repository;
 
 import com.prototyne.domain.ADD_set;
 import com.prototyne.domain.User;
+import com.prototyne.domain.enums.AddsetTitle;
 import com.prototyne.domain.mapping.Additional;
 import com.prototyne.web.dto.UserDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AdditionalRepository extends JpaRepository<Additional, Long> {
     List<Additional> findByUserId(Long userId);
     void deleteByUserId(Long userId);
+
+    Optional<Additional> findByUserAndAddSet_Title(User user, AddsetTitle title);
 }

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -71,13 +71,27 @@ public class UserSignupServiceImpl implements UserSignupService {
 
     @Override
     public void saveAdditionalInfo(User user, UserDto.UserAddInfoRequest request) {
-        saveAddSetInfo(user, AddsetTitle.직업, Collections.singletonList(request.getOccupation()));
-        saveAddSetInfo(user, AddsetTitle.소득수준, Collections.singletonList(String.valueOf(request.getIncome())));
-        saveAddSetInfo(user, AddsetTitle.관심사, request.getInterests());
-        saveAddSetInfo(user, AddsetTitle.가족구성, Collections.singletonList(request.getFamilyComposition()));
-        saveAddSetInfo(user, AddsetTitle.관심제품유형, request.getProductTypes());
-        saveAddSetInfo(user, AddsetTitle.스마트기기_기종, request.getPhones());
-        saveAddSetInfo(user, AddsetTitle.건강상태, Collections.singletonList(String.valueOf(request.getHealthStatus())));
+        if (request.getOccupation() != null) {
+            saveAddSetInfo(user, AddsetTitle.직업, Collections.singletonList(request.getOccupation()));
+        }
+        if (request.getIncome() != null) {
+            saveAddSetInfo(user, AddsetTitle.소득수준, Collections.singletonList(String.valueOf(request.getIncome())));
+        }
+        if (request.getInterests() != null && !request.getInterests().isEmpty()) {
+            saveAddSetInfo(user, AddsetTitle.관심사, request.getInterests());
+        }
+        if (request.getFamilyComposition() != null) {
+            saveAddSetInfo(user, AddsetTitle.가족구성, Collections.singletonList(request.getFamilyComposition()));
+        }
+        if (request.getProductTypes() != null && !request.getProductTypes().isEmpty()) {
+            saveAddSetInfo(user, AddsetTitle.관심제품유형, request.getProductTypes());
+        }
+        if (request.getPhones() != null && !request.getPhones().isEmpty()) {
+            saveAddSetInfo(user, AddsetTitle.스마트기기_기종, request.getPhones());
+        }
+        if (request.getHealthStatus() != null) {
+            saveAddSetInfo(user, AddsetTitle.건강상태, Collections.singletonList(String.valueOf(request.getHealthStatus())));
+        }
     }
 
 

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -1,9 +1,5 @@
 package com.prototyne.service.SignupService;
 
-import com.prototyne.apiPayload.ApiResponse;
-import com.prototyne.apiPayload.code.status.ErrorStatus;
-import com.prototyne.apiPayload.exception.handler.TempHandler;
-import com.prototyne.converter.UserConverter;
 import com.prototyne.domain.ADD_set;
 import com.prototyne.domain.User;
 import com.prototyne.domain.enums.AddsetTitle;
@@ -12,19 +8,13 @@ import com.prototyne.repository.ADD_setRepository;
 import com.prototyne.repository.AdditionalRepository;
 import com.prototyne.repository.UserRepository;
 import com.prototyne.service.LoginService.JwtManager;
-import com.prototyne.service.LoginService.KakaoService;
-import com.prototyne.service.LoginService.KakaoServiceImpl;
 import com.prototyne.web.dto.UserDto;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
-
-
 import java.util.List;
 
 @Slf4j
@@ -35,42 +25,36 @@ public class UserSignupServiceImpl implements UserSignupService {
     private final AdditionalRepository additionalRepository;
     private final ADD_setRepository addSetRepository;
     @Lazy
-    private final KakaoServiceImpl kakaoService;
     private final JwtManager jwtManager;
     @Override
     public UserDto.UserSignUpResponse signup(String aouthToken,
                        UserDto.UserDetailRequest userDetailRequest,
                        UserDto.UserAddInfoRequest addInfoRequest){
-        UserDto.UserInfoResponse kakaoUserInfo = kakaoService.getKakaoInfo(aouthToken);
-        // 카카오 이메일로 기존 회원이 존재하는지 여부 조회
-        User existingUser = userRepository.findByEmail(kakaoUserInfo.getKakaoAccount().getEmail());
+        Long userId = jwtManager.validateJwt(aouthToken);
+        // id로 기존 회원이 존재하는지 여부 조회
+        User existingUser = userRepository.findById(userId).orElse(null);
 
-        if(existingUser != null){
-            if(existingUser.getSignupComplete()) {
-                throw new RuntimeException("이미 회원가입이 완료된 사용자입니다.");
-            }
-            else {
-                // 회원가입이 완료되지 않은 사용자라면,
-                // 사용자 정보를 유저 db에서 삭제(동일 유저에 대한 정보 중복 저장 방지)
-                userRepository.delete(existingUser);
-            }
+        if(existingUser != null && existingUser.getSignupComplete()) {
+            throw new RuntimeException("이미 회원가입이 완료된 사용자입니다.");
+        }else if(existingUser == null){
+            throw new RuntimeException("카카오 로그인을 먼저 진행해주세요.");
         }
 
         // 회원가입 로직: 카카오 로그인 -> 필수 정보 입력 -> 추가 정보 입력 -> 그 후에 회원가입 완료(db에 저장)
-        User newUser = UserConverter.toSignedUser(kakaoUserInfo, userDetailRequest);
-        userRepository.save(newUser);
+        existingUser.setDetail(userDetailRequest);
 
-        saveAdditionalInfo(newUser, addInfoRequest);
+//        User newUser = UserConverter.toSignedUser(existingUser, userDetailRequest);
+        userRepository.save(existingUser);
 
-        newUser.setSignupComplete(true);
+        saveAdditionalInfo(existingUser, addInfoRequest);
 
-        String jwtToken = jwtManager.createJwt(newUser.getId());
-        System.out.println("회원가입 테스트용 토큰 발급: "+ jwtToken);
-
-        return new UserDto.UserSignUpResponse(newUser.getId(), "회원가입이 완료되었습니다.");
+        return new UserDto.UserSignUpResponse(existingUser.getId(), "회원가입이 완료되었습니다.");
     }
 
     public void saveAddSetInfo(User user, AddsetTitle title, List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return;
+        }
         String value = String.join(",", values);  // List<String>을 콤마로 구분된 문자열로 변환
 
         ADD_set addSet = addSetRepository.findByTitleAndValue(title, value)

--- a/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
+++ b/src/main/java/com/prototyne/service/SignupService/UserSignupServiceImpl.java
@@ -42,7 +42,7 @@ public class UserSignupServiceImpl implements UserSignupService {
 
         // 회원가입 로직: 카카오 로그인 -> 필수 정보 입력 -> 추가 정보 입력 -> 그 후에 회원가입 완료(db에 저장)
         existingUser.setDetail(userDetailRequest);
-
+        existingUser.setSignupComplete(true);
 //        User newUser = UserConverter.toSignedUser(existingUser, userDetailRequest);
         userRepository.save(existingUser);
 

--- a/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
+++ b/src/main/java/com/prototyne/service/UserService/UserDetailServiceImpl.java
@@ -111,15 +111,28 @@ public class UserDetailServiceImpl implements UserDetailService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserPrincipalNotFoundException(userId + "에 해당하는 회원이 없습니다."));
 
-        // 각 필드에 대해 기존 정보를 조회하고, 존재하면 업데이트, 존재하지 않으면 새로 추가
-        updateAddSetInfo(user, AddsetTitle.직업, addInfo.getOccupation());
-        updateAddSetInfo(user, AddsetTitle.소득수준, String.valueOf(addInfo.getIncome()));
-        updateAddSetInfo(user, AddsetTitle.관심사, addInfo.getInterests() != null ? String.join(",", addInfo.getInterests()) : null);
-        updateAddSetInfo(user, AddsetTitle.가족구성, addInfo.getFamilyComposition());
-        updateAddSetInfo(user, AddsetTitle.관심제품유형, addInfo.getProductTypes() != null ? String.join(",", addInfo.getProductTypes()) : null);
-        updateAddSetInfo(user, AddsetTitle.스마트기기_기종, addInfo.getPhones() != null ? String.join(",", addInfo.getPhones()) : null);
-        updateAddSetInfo(user, AddsetTitle.건강상태, String.valueOf(addInfo.getHealthStatus()));
-
+        // addInfo(dto)의 필드값들에 대하여, 값이 존재하는 경우에만 업로드해준다.
+        if(addInfo.getOccupation() != null){
+            updateAddSetInfo(user ,AddsetTitle.직업, addInfo.getOccupation());
+        }
+        if (addInfo.getIncome() != null) {
+            updateAddSetInfo(user, AddsetTitle.소득수준, String.valueOf(addInfo.getIncome()));
+        }
+        if (addInfo.getInterests() != null) {
+            updateAddSetInfo(user, AddsetTitle.관심사, String.join(",", addInfo.getInterests()));
+        }
+        if (addInfo.getFamilyComposition() != null) {
+            updateAddSetInfo(user, AddsetTitle.가족구성, addInfo.getFamilyComposition());
+        }
+        if (addInfo.getProductTypes() != null) {
+            updateAddSetInfo(user, AddsetTitle.관심제품유형, String.join(",", addInfo.getProductTypes()));
+        }
+        if (addInfo.getPhones() != null) {
+            updateAddSetInfo(user, AddsetTitle.스마트기기_기종, String.join(",", addInfo.getPhones()));
+        }
+        if (addInfo.getHealthStatus() != null) {
+            updateAddSetInfo(user, AddsetTitle.건강상태, String.valueOf(addInfo.getHealthStatus()));
+        }
         return userConverter.toUserDetailResponse(user, addInfo).getAddInfo();
     }
 

--- a/src/main/java/com/prototyne/web/controller/MyController.java
+++ b/src/main/java/com/prototyne/web/controller/MyController.java
@@ -35,7 +35,7 @@ public class MyController {
         return ApiResponse.onSuccess(userDetailResponse);
     }
 
-    @PatchMapping("/basicInfo")
+    @PatchMapping("/basicinfo")
     @Operation(summary = "필수 정보 수정 API - 인증 필요",
             description = """
                     유저의 필수 정보를 수정합니다.
@@ -52,7 +52,7 @@ public class MyController {
 
     }
 
-    @PatchMapping("/addInfo")
+    @PatchMapping("/addinfo")
     @Operation(summary = "추가 정보 수정 API - 인증 필요",
             description = """
                     유저의 추가 정보를 수정합니다. - 수정 필요한 key-value 만 입력

--- a/src/main/java/com/prototyne/web/controller/OauthController.java
+++ b/src/main/java/com/prototyne/web/controller/OauthController.java
@@ -35,7 +35,8 @@ public class OauthController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입 API - 인증 필요",
-            description = "회원가입 API - 인증 필요",
+            description = """
+                    Body는 하단의 /my/basicinfo , /my/addinfo api의 설명 참고""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<UserDto.UserSignUpResponse> signup(HttpServletRequest token, @RequestBody @Valid UserDto.UserSignUpRequest signUpRequest) {
         String aouthtoken = jwtManager.getToken(token);

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -169,12 +169,12 @@ public class UserDto {
     @NoArgsConstructor
     public static class AddInfo {
         private String occupation;
-        private int income;
+        private Integer income;
         private List<String> interests;
         private String familyComposition;
         private List<String> productTypes;
         private List<String> phones;
-        private int healthStatus;
+        private Integer healthStatus;
 
     }
 

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -2,11 +2,10 @@ package com.prototyne.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.prototyne.domain.User;
 import com.prototyne.domain.enums.Gender;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 
@@ -19,16 +18,16 @@ public class UserDto {
         private String profileUrl;
         private Integer tickets;
         private Gender gender;
-        private LocalDateTime birth;
+        private LocalDate birth;
     }
 
     @Getter
     public static class UserDetailRequest {
         private final Integer familyMember;
         private final Gender Gender;
-        private final LocalDateTime Birth;
+        private final LocalDate Birth;
 
-        public UserDetailRequest(Integer familyMember, Gender gender, LocalDateTime birth) {
+        public UserDetailRequest(Integer familyMember, Gender gender, LocalDate birth) {
             this.familyMember = familyMember;
             this.Gender = gender;
             this.Birth = birth;

--- a/src/main/java/com/prototyne/web/dto/UserDto.java
+++ b/src/main/java/com/prototyne/web/dto/UserDto.java
@@ -145,7 +145,7 @@ public class UserDto {
     @AllArgsConstructor
     public static class UserSignUpResponse {
         private final Long userId;
-        private final String token;
+        private final String msg;
     }
 
     @Data


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#39 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
- 에러 처리 signUpComplete 필드 기준으로 에러 처리 코드 추가
- 성공적으로 회원가입 완료 시 signUpComplete 필드 true값으로 변형 후 db 저장
- id, 성공 여부만 응답해주는 로직으로 변경

**⚠️ 추가 발견된 버그**
- 추가 정보 수정(PATCH /my/addInfo) 시, 기존 정보가 삭제되지 않고 그대로 db에 남아있는 현상 발견 
➡️ 해결 완료

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 회원가입 - `POST /oauth2/signup`
![image](https://github.com/user-attachments/assets/f0d2f5e5-47f5-4f51-834e-08bf3a04bb14)

### 추가 정보 수정 - `PATCH /my/addInfo`
![image](https://github.com/user-attachments/assets/190f4171-358b-4504-be6c-c7880d1cc8aa)
![image](https://github.com/user-attachments/assets/e99199c1-39ba-4c32-9676-33fc6dd471de)
- db에 기존 내용은 삭제되고 업데이트 된 내용만 성공적으로 반영 확인

