### PR TITLE
[Feat] 북마크 목록조회/등록/해제 API 구현

### DIFF
--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -17,7 +17,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     LOGIN_ERROR_ID(HttpStatus.BAD_REQUEST, "LOGIN4001", "존재하지 않는 유저입니다"),
 
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
+
+    // 로그인하지 않은 사용자가 북마크 여부 변경시
+    HEART_ERROR_ID(HttpStatus.BAD_REQUEST, "HEART4001", "로그인이 필요합니다"),
+    // 존재하지 않는 이벤트의 북마크 여부 변경시
+    HEART_ERROR_EVENT(HttpStatus.BAD_REQUEST, "HEART4002", "잘못된 이벤트 접근입니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/prototyne/converter/HeartConverter.java
+++ b/src/main/java/com/prototyne/converter/HeartConverter.java
@@ -1,0 +1,47 @@
+package com.prototyne.converter;
+
+import com.prototyne.domain.Event;
+import com.prototyne.domain.Product;
+import com.prototyne.domain.User;
+import com.prototyne.domain.mapping.Heart;
+import com.prototyne.web.dto.HeartDto;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class HeartConverter {
+    public static HeartDto.HeartResponseDTO toHeartResponseDTO(User user, List<Heart> hearts) {
+        List<HeartDto.HeartResponseDTO.ProductInfo> productInfos = hearts.stream()
+                .map(heart -> {
+                    Event event = heart.getEvent();
+                    Product product = event.getProduct();
+                    return HeartDto.HeartResponseDTO.ProductInfo.builder()
+                            .productId(product.getId())
+                            .name(product.getName())
+                            .reqTickets(product.getReqTickets())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return HeartDto.HeartResponseDTO.builder()
+                .userId(user.getId())
+                .products(productInfos)
+                .build();
+    }
+
+    public static HeartDto.HeartActionResponseDTO toHeartActionResponseDTO(Long eventId, String message) {
+        return HeartDto.HeartActionResponseDTO.builder()
+                .eventId(eventId)
+                .message(message)
+                .build();
+    }
+
+    public static Heart toHeartEntity(User user, Event event) {
+        return Heart.builder()
+                .user(user)
+                .event(event)
+                .build();
+    }
+}

--- a/src/main/java/com/prototyne/converter/HeartConverter.java
+++ b/src/main/java/com/prototyne/converter/HeartConverter.java
@@ -4,6 +4,7 @@ import com.prototyne.domain.Event;
 import com.prototyne.domain.Product;
 import com.prototyne.domain.User;
 import com.prototyne.domain.mapping.Heart;
+import com.prototyne.repository.HeartRepository;
 import com.prototyne.web.dto.HeartDto;
 import org.springframework.stereotype.Component;
 
@@ -12,15 +13,20 @@ import java.util.stream.Collectors;
 
 @Component
 public class HeartConverter {
-    public static HeartDto.HeartResponseDTO toHeartResponseDTO(User user, List<Heart> hearts) {
+    public static HeartDto.HeartResponseDTO toHeartResponseDTO(User user, List<Heart> hearts, HeartRepository heartRepository) {
         List<HeartDto.HeartResponseDTO.ProductInfo> productInfos = hearts.stream()
                 .map(heart -> {
                     Event event = heart.getEvent();
                     Product product = event.getProduct();
+
+                    Long count = heartRepository.countByProductId(product.getId());
+
                     return HeartDto.HeartResponseDTO.ProductInfo.builder()
                             .productId(product.getId())
                             .name(product.getName())
                             .reqTickets(product.getReqTickets())
+                            .thumbnailUrl(product.getThumbnailUrl())
+                            .count(count)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/prototyne/repository/EventRepository.java
+++ b/src/main/java/com/prototyne/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/prototyne/repository/HeartRepository.java
+++ b/src/main/java/com/prototyne/repository/HeartRepository.java
@@ -4,6 +4,8 @@ import com.prototyne.domain.User;
 import com.prototyne.domain.Event;
 import com.prototyne.domain.mapping.Heart;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,7 @@ import java.util.Optional;
 public interface HeartRepository extends JpaRepository<Heart, Long> {
     List<Heart> findByUser(User user); // 사용자가 누른 좋아요 목록 조회
     Optional<Heart> findByUserAndEvent(User user, Event event);
+
+    @Query("SELECT COUNT(h) FROM Heart h WHERE h.event.product.id = :productId")
+    Long countByProductId(@Param("productId") Long productId);
 }

--- a/src/main/java/com/prototyne/repository/HeartRepository.java
+++ b/src/main/java/com/prototyne/repository/HeartRepository.java
@@ -1,0 +1,14 @@
+package com.prototyne.repository;
+
+import com.prototyne.domain.User;
+import com.prototyne.domain.Event;
+import com.prototyne.domain.mapping.Heart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+    List<Heart> findByUser(User user); // 사용자가 누른 좋아요 목록 조회
+    Optional<Heart> findByUserAndEvent(User user, Event event);
+}

--- a/src/main/java/com/prototyne/service/HeartService/HeartService.java
+++ b/src/main/java/com/prototyne/service/HeartService/HeartService.java
@@ -1,0 +1,12 @@
+package com.prototyne.service.HeartService;
+
+import com.prototyne.web.dto.HeartDto;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
+
+public interface HeartService {
+    HeartDto.HeartResponseDTO getLikeList(String accessToken) throws UserPrincipalNotFoundException;
+    HeartDto.HeartActionResponseDTO likeEvent(Long eventId, String accessToken);
+    HeartDto.HeartActionResponseDTO unlikeEvent(Long eventId, String accessToken);
+
+}

--- a/src/main/java/com/prototyne/service/HeartService/HeartServiceImpl.java
+++ b/src/main/java/com/prototyne/service/HeartService/HeartServiceImpl.java
@@ -39,7 +39,7 @@ public class HeartServiceImpl implements HeartService{
 
         log.info("accessToken in Service",accessToken);
 
-        return HeartConverter.toHeartResponseDTO(user, hearts);
+        return HeartConverter.toHeartResponseDTO(user, hearts, heartRepository);
     }
 
     @Transactional

--- a/src/main/java/com/prototyne/service/HeartService/HeartServiceImpl.java
+++ b/src/main/java/com/prototyne/service/HeartService/HeartServiceImpl.java
@@ -1,0 +1,79 @@
+package com.prototyne.service.HeartService;
+
+import com.prototyne.apiPayload.code.status.ErrorStatus;
+import com.prototyne.apiPayload.exception.handler.TempHandler;
+import com.prototyne.converter.HeartConverter;
+import com.prototyne.domain.Event;
+import com.prototyne.domain.User;
+import com.prototyne.domain.mapping.Heart;
+import com.prototyne.repository.EventRepository;
+import com.prototyne.repository.HeartRepository;
+import com.prototyne.repository.UserRepository;
+import com.prototyne.service.LoginService.JwtManager;
+import com.prototyne.web.dto.HeartDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HeartServiceImpl implements HeartService{
+    private final HeartRepository heartRepository;
+    private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+    private final JwtManager jwtManager;
+
+    @Override
+    public HeartDto.HeartResponseDTO getLikeList(String accessToken) throws UserPrincipalNotFoundException{
+        Long userId = jwtManager.validateJwt(accessToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserPrincipalNotFoundException(userId + "에 해당하는 회원이 없습니다."));
+
+        // 사용자가 좋아요 누른 이벤트 목록 조회
+        List<Heart> hearts = heartRepository.findByUser(user);
+
+        log.info("accessToken in Service",accessToken);
+
+        return HeartConverter.toHeartResponseDTO(user, hearts);
+    }
+
+    @Transactional
+    @Override
+    public HeartDto.HeartActionResponseDTO likeEvent(Long eventId, String accessToken) {
+        Long userId = jwtManager.validateJwt(accessToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid user ID: " + userId));
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid event ID: " + eventId));
+
+        // 이미 좋아요를 누른 경우 처리
+        if (heartRepository.findByUserAndEvent(user, event).isPresent()) {
+            throw new IllegalArgumentException("이미 좋아요를 누른 이벤트입니다.");
+        }
+
+        Heart heart = HeartConverter.toHeartEntity(user, event);
+        heartRepository.save(heart);
+        return HeartConverter.toHeartActionResponseDTO(eventId, "북마크가 성공적으로 등록되었습니다.");
+    }
+
+    @Transactional
+    @Override
+    public HeartDto.HeartActionResponseDTO unlikeEvent(Long eventId, String accessToken) {
+        Long userId = jwtManager.validateJwt(accessToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.HEART_ERROR_ID));
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.HEART_ERROR_EVENT));
+
+        Heart heart = heartRepository.findByUserAndEvent(user, event)
+                .orElseThrow(() -> new IllegalArgumentException("해제할 북마크가 없습니다."));
+
+        heartRepository.delete(heart); // 북마크 삭제
+        return HeartConverter.toHeartActionResponseDTO(eventId, "북마크가 성공적으로 해제되었습니다.");
+    }
+}

--- a/src/main/java/com/prototyne/web/controller/HeartController.java
+++ b/src/main/java/com/prototyne/web/controller/HeartController.java
@@ -1,0 +1,56 @@
+package com.prototyne.web.controller;
+
+import com.prototyne.apiPayload.ApiResponse;
+import com.prototyne.service.HeartService.HeartServiceImpl;
+import com.prototyne.web.dto.HeartDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class HeartController {
+    private final HeartServiceImpl heartService;
+
+    @Tag(name = "${swagger.tag.like}")
+    @GetMapping("/like/list")
+    @Operation(summary = "유저 북마크 목록 조회 API - 인증 필요",
+        description = "유저 북마크 목록 조회 API - 인증 필요",
+        security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<HeartDto.HeartResponseDTO> likeList(HttpServletRequest request) throws Exception {
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+
+        HeartDto.HeartResponseDTO heartResponse = heartService.getLikeList(accessToken);
+        return ApiResponse.onSuccess(heartResponse);
+    }
+
+    @Tag(name = "${swagger.tag.like}")
+    @PostMapping("/like/{eventId}")
+    @Operation(summary = "유저 북마크 등록 API - 인증 필요",
+            description = "유저 북마크 등록 API - 인증 필요",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<HeartDto.HeartActionResponseDTO> likeEvent(@PathVariable Long eventId, HttpServletRequest request){
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+
+        HeartDto.HeartActionResponseDTO response = heartService.likeEvent(eventId, accessToken);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Tag(name = "${swagger.tag.like}")
+    @DeleteMapping("/unlike/{eventId}")
+    @Operation(summary = "유저 북마크 해제 API - 인증 필요",
+            description = "유저 북마크 해제 API - 인증 필요",
+            security = {@SecurityRequirement(name = "session-token")})
+    public ApiResponse<HeartDto.HeartActionResponseDTO> unlikeEvent(@PathVariable Long eventId, HttpServletRequest request){
+        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+
+        HeartDto.HeartActionResponseDTO response = heartService.unlikeEvent(eventId, accessToken);
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/com/prototyne/web/dto/HeartDto.java
+++ b/src/main/java/com/prototyne/web/dto/HeartDto.java
@@ -1,0 +1,44 @@
+package com.prototyne.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class HeartDto {
+    @Builder
+    @Getter
+    public static class HeartRequestDTO {
+        private Long eventId;   // 이벤트 id
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HeartResponseDTO {
+        private Long userId;
+        private List<ProductInfo> products;
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ProductInfo{
+            private Long productId;
+            private String name;
+            private Integer reqTickets;
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HeartActionResponseDTO {
+        private Long eventId;   // 등록 or 해제한 이벤트 id
+        private String message;
+    }
+}

--- a/src/main/java/com/prototyne/web/dto/HeartDto.java
+++ b/src/main/java/com/prototyne/web/dto/HeartDto.java
@@ -30,6 +30,8 @@ public class HeartDto {
             private Long productId;
             private String name;
             private Integer reqTickets;
+            private String thumbnailUrl;
+            private Long count;
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#16 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
feat: 북마크 목록 조회 API 구현
feat: 북마크 등록 API 구현
feat: 북마크 해제 API 구현

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
사용자가 북마크한 목록들에 필요한 Product list내에 각각 product id와 name, reqTicket을 담았는데, 이외에 더 필요한 것은 없는지 궁금합니다. (ui는 확인해보니 몇 명 신청했는가를 포함하는지 헷갈립니다.) 
<img width="189" alt="Q1" src="https://github.com/user-attachments/assets/7956c508-fa8a-4852-aee5-7fdf2f790a42">
<img width="189" alt="Q1-2" src="https://github.com/user-attachments/assets/09d04838-de88-4a45-a04a-9d33180df77e">


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
## API 테스트
### 1. 북마크 목록 조회 (GET /like/list)
- 좋아요 누른 유저의 id, 북마크된 event 별 product 객체의 리스트 반환
- 헤더에 jwt 토큰 값을 넣어 사용자 인증하여 로그인하지 않은 경우는 에러 처리
<img width="633" alt="북마크GET_200" src="https://github.com/user-attachments/assets/46c20ae2-5c40-4048-b36a-767fc918102b">


### 2. 북마크 등록 (POST /like/{eventId})
- 북마크 등록한 event id와 성공메시지 반환
- 헤더에 jwt 토큰 값을 넣어 사용자 인증하여 로그인하지 않은 경우는 에러 처리
- 이미 북마크 등록된 event일 경우 메시지와 함께 에러 처리
<img width="653" alt="북마크POST_200" src="https://github.com/user-attachments/assets/2969ef72-f9ce-4c31-b5c0-4f511a46c596">
<br/>
<img width="671" alt="북마크POST_500" src="https://github.com/user-attachments/assets/d342869a-f0ac-4baa-a1da-3d23fd18ff96">


### 3. 북마크 해제 (GET /unlike/{eventId})
- 북마크 해제한 event id와 성공메시지 반환
- 헤더에 jwt 토큰 값을 넣어 사용자 인증하여 로그인하지 않은 경우는 에러 처리
- 이미 북마크 해제된 event일 경우 메시지와 함께 에러 처리
<img width="617" alt="북마크DEL_200" src="https://github.com/user-attachments/assets/767ef9ee-8d13-42b4-b214-df1a04bfedcc">
<br/>
<img width="632" alt="북마크DEL_500" src="https://github.com/user-attachments/assets/da48386f-a672-474c-956d-4ae914e797d3">



