### PR TITLE
Docs: EventServiceImpl 및 관련 response DTO 수정

### DIFF
--- a/src/main/java/com/prototyne/converter/ProductConverter.java
+++ b/src/main/java/com/prototyne/converter/ProductConverter.java
@@ -14,8 +14,8 @@ public class ProductConverter {
 
     // 홈 화면 형식
     public static ProductDTO.HomeResponse toHome (List<ProductDTO.EventResponse> pL,
-                                                  List<ProductDTO.EventResponse> iL,
-                                                  List<ProductDTO.EventResponse> nL) {
+                                                  List<ProductDTO.SearchResponse> iL,
+                                                  List<ProductDTO.SearchResponse> nL) {
         return ProductDTO.HomeResponse.builder()
                 .popularList(pL).imminentList(iL).newList(nL).build();
     }

--- a/src/main/java/com/prototyne/web/controller/ProductController.java
+++ b/src/main/java/com/prototyne/web/controller/ProductController.java
@@ -29,7 +29,7 @@ public class ProductController {
     @Operation(summary = "홈 화면 조회 API - 인증 필요",
             description = """
                 홈 화면 조회 \n
-                인기순(3), 마감 임박(2), 신규 등록(2) \n""",
+                인기순 2개, 마감 임박순 3개, 신규 등록순 3개 \n""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<ProductDTO.HomeResponse> getHome(HttpServletRequest token) {
         String oauthToken = jwtManager.getToken(token);
@@ -40,8 +40,11 @@ public class ProductController {
     @GetMapping("/list")
     @Operation(summary = "시제품 목록 조회 API - 인증 필요" ,
             description = """
-                정렬 타입 입력 ("" 없이 입력)\n
-                type = "popular"(인기순, 기본) | "imminent"(마감 임박순) | "new"(최신 등록순) \n""",
+                정렬 타입 입력 ("" 없이 입력) \n
+                type = "popular"(인기순, 기본) | "imminent"(마감 임박순) | "new"(최신 등록순) \n
+                ** 인기순: 북마크 수 + 투자 수의 평균으로 \n
+                ** 마감 임박순: 신청 마감이 3일 남은 시제품만 \n
+                ** 최신 등록순: 해당 주에 등록된 시제품만""",
             security = {@SecurityRequirement(name = "session-token")})
     public ApiResponse<List<ProductDTO.EventResponse>> getEventsList(
             HttpServletRequest token,

--- a/src/main/java/com/prototyne/web/dto/ProductDTO.java
+++ b/src/main/java/com/prototyne/web/dto/ProductDTO.java
@@ -15,8 +15,8 @@ public class ProductDTO {
     @Builder
     public static class HomeResponse {
         List<EventResponse> popularList;
-        List<EventResponse> imminentList;
-        List<EventResponse> newList;
+        List<SearchResponse> imminentList;
+        List<SearchResponse> newList;
     }
 
     // 시제품 정렬 응답 형식


### PR DESCRIPTION
## 📌 관련 이슈
#69 

## ✨ PR 내용
EventServiceImpl 및 관련 response DTO 수정
- 응답 리스트 개수 2, 3, 3으로 수정
- 타입별 시제품 가져오는 메소드(getEvents) 분리
- ProductDTO.HomeResponse 수정 - imminent와 new 타입의 경우, d-Day 반환하도록


> ![image](https://github.com/user-attachments/assets/64441085-a8a6-4b76-8cf7-8f165f084d64)
popular리스트의 경우 investCount 반환


>![image](https://github.com/user-attachments/assets/6d38281a-8768-492c-bde7-7148bc86aa7b)
그 외 리스트 Dday 반환


> ![image](https://github.com/user-attachments/assets/7e8cb070-c138-4d0c-9310-c7db0b5b1b06)
타입별 시제품 목록 조회는 그대로 investCount 반환