### PR TITLE
Fix:체험 신청 API-investment테이블의 apply필드 값 true로 저장

### DIFF
--- a/src/main/java/com/prototyne/converter/InvestmentConverter.java
+++ b/src/main/java/com/prototyne/converter/InvestmentConverter.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 @Component
 @Builder
 public class InvestmentConverter {
-    public Investment toInvestment(User user, Event event)
+    public Investment toInvestment(User user, Event event, Boolean apply)
     {
         return Investment.builder()
                 .user(user)
                 .event(event)
-                .apply(true)
+                .apply(apply)
                 .build();
     }
 }

--- a/src/main/java/com/prototyne/converter/InvestmentConverter.java
+++ b/src/main/java/com/prototyne/converter/InvestmentConverter.java
@@ -15,6 +15,7 @@ public class InvestmentConverter {
         return Investment.builder()
                 .user(user)
                 .event(event)
+                .apply(true)
                 .build();
     }
 }

--- a/src/main/java/com/prototyne/service/ApplicationService/ApplicationServiceImpl.java
+++ b/src/main/java/com/prototyne/service/ApplicationService/ApplicationServiceImpl.java
@@ -68,7 +68,7 @@ public class ApplicationServiceImpl implements ApplicationService {
                     .ticketChange(-reqTickets)
                     .build();
 
-            Investment investment = investmentConverter.toInvestment(user, event);
+            Investment investment = investmentConverter.toInvestment(user, event, apply);
 
             // TicketService를 사용하여 티켓 저장
             ticketService.saveTicket(ticketListDto, user);


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#71 
## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
체험 신청 API에서 apply값이 true일 경우, investment 테이블의 필드값 추가 중, apply값 true로 저장되도록 수정
## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
![image](https://github.com/user-attachments/assets/c4596a92-acae-48b5-9611-cbd5ad47d699)
![image](https://github.com/user-attachments/assets/d3bb2a5f-b999-4367-8643-582a210ae2c9)
apply값이 true일 경우에만 investment 객체를 생성하는 것이어서 
apply값을 항상 true로 저장되도록 수정하였습니다.
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/04893ca2-32ba-4395-aebc-e25fcfcf7397)
