### PR TITLE
Fix: 후기 작성 이미지 API, 후기 작성 텍스트 API-사용자에러 처리

### DIFF
--- a/src/main/java/com/prototyne/repository/InvestmentRepository.java
+++ b/src/main/java/com/prototyne/repository/InvestmentRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 @Repository
 public interface InvestmentRepository extends JpaRepository<Investment, Long> {
     Optional<Investment> findByUserIdAndEventId(Long userId, Long eventId);
+    Optional<Investment> findByUserIdAndId(Long userId, Long InvestmentId);
 
 
 }

--- a/src/main/java/com/prototyne/service/FeedbackService/FeedbackServiceImpl.java
+++ b/src/main/java/com/prototyne/service/FeedbackService/FeedbackServiceImpl.java
@@ -33,10 +33,10 @@ public class FeedbackServiceImpl implements FeedbackService{
     @Override
     public FeedbackDTO UpdateFeedbacks(String accessToken, Long investmentId, FeedbackDTO feedbackDTO){
 
-        Long id = jwtManager.validateJwt(accessToken);
-        User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
+        Long userId = jwtManager.validateJwt(accessToken);
+        User user = userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
 
-        Investment investment = investmentRepository.findById(investmentId)
+        Investment investment = investmentRepository.findByUserIdAndId(userId,investmentId)
                 .orElseThrow(() -> new TempHandler(ErrorStatus.INVESTMENT_ERROR_ID));
 
         Feedback feedback = feedbackRepository.findByInvestmentId(investmentId).orElseGet(() -> Feedback.builder()
@@ -59,13 +59,13 @@ public class FeedbackServiceImpl implements FeedbackService{
     }
 
     public FeedbackImageDTO CreateFeedbacksImage(String accessToken, Long investmentId, String directory, List<MultipartFile> feedbackImages){
-        Long id = jwtManager.validateJwt(accessToken);
-        User user = userRepository.findById(id).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
+        Long userId = jwtManager.validateJwt(accessToken);
+        User user = userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
 
         if(feedbackImages.isEmpty()||feedbackImages.size()>3){
             throw new TempHandler(ErrorStatus.INVALID_IMAGE_COUNT);
         }
-        Investment investment =investmentRepository.findById(investmentId).orElseThrow(() -> new TempHandler(ErrorStatus.INVESTMENT_ERROR_ID));
+        Investment investment =investmentRepository.findByUserIdAndId(userId,investmentId).orElseThrow(() -> new TempHandler(ErrorStatus.INVESTMENT_ERROR_ID));
 
         Feedback feedback = feedbackRepository.findByInvestmentId(investmentId).orElseGet(() -> {
             Feedback newFeedback = Feedback.builder()
@@ -91,7 +91,7 @@ public class FeedbackServiceImpl implements FeedbackService{
         }
 
         return FeedbackImageDTO.builder()
-                .id(id)
+                .id(userId)
                 .imageUrls(imageUrls)
                 .build();
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#80

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
후기 작성 텍스트 API, 후기 작성 이미지 API에서 다른 사용자가 체험 신청해서 생긴 investment에 대한 후기 작성이 가능했음
->investment테이블을 investmentId로만 찾기-->investmentId와 userId로 찾기 변경
-->다른 사람이 체험 신청해서 생긴 investment에 접근하면 INVESTMENT4001 "존재하지 않는 나의 시제품입니다."라는 에러 처리


사용자 플래그 2로 입력했을 경우, 사용자 아이디가 1인 investment테이블의 필드값에 접근이 가능했음-->수정
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/c49d8202-5115-4889-a4e3-eee34ab11808">

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
다른 사용자의 investment 필드값에 접근할 경우
![image](https://github.com/user-attachments/assets/dc274179-49de-4e5b-8191-24437ed06c3b)

나의 investment 필드값에 접근할 경우
![image](https://github.com/user-attachments/assets/c01c4ff9-cede-4a1e-b480-c95fbe22ff75)

