### PR TITLE
Fix:체험 신청 API-이미 존재하는 investment 관련 에러 추가

### DIFF
--- a/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/prototyne/apiPayload/code/status/ErrorStatus.java
@@ -50,7 +50,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     INVALID_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "FEEDBACK IMAGE4001", "이미지 개수의 범위를 벗어났습니다."),
 
-    TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다.");
+    TiCKET_LACK_ERROR(HttpStatus.BAD_REQUEST, "TiCKET4001", "티켓이 부족합니다."),
+
+    EVENT_USER_EXIST(HttpStatus.BAD_REQUEST,"EVENT4001","이미 체험 신청한 시제품입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/prototyne/repository/InvestmentRepository.java
+++ b/src/main/java/com/prototyne/repository/InvestmentRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface InvestmentRepository extends JpaRepository<Investment, Long> {
     Optional<Investment> findByUserIdAndEventId(Long userId, Long eventId);
     Optional<Investment> findByUserIdAndId(Long userId, Long InvestmentId);
+    Investment findByUserIdAndEventIdAndApply(Long userId, Long eventId, Boolean apply);
 
 
 }

--- a/src/main/java/com/prototyne/service/ApplicationService/ApplicationServiceImpl.java
+++ b/src/main/java/com/prototyne/service/ApplicationService/ApplicationServiceImpl.java
@@ -4,10 +4,7 @@ import com.prototyne.apiPayload.code.status.ErrorStatus;
 import com.prototyne.apiPayload.exception.handler.TempHandler;
 import com.prototyne.converter.InvestmentConverter;
 import com.prototyne.domain.*;
-import com.prototyne.repository.AlarmRespository;
-import com.prototyne.repository.EventRepository;
-import com.prototyne.repository.ProductRepository;
-import com.prototyne.repository.UserRepository;
+import com.prototyne.repository.*;
 import com.prototyne.service.LoginService.JwtManager;
 import com.prototyne.service.ProductService.EventService;
 import com.prototyne.service.TicketService.TicketService;
@@ -32,6 +29,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     private final EventRepository eventRepository;
     private final InvestmentConverter investmentConverter;
     private final EventService eventService;
+    private final InvestmentRepository investmentRepository;
 
     @Override
     public InvestmentDTO.ApplicationResponse Application(String accessToken, Long eventId) {
@@ -39,6 +37,7 @@ public class ApplicationServiceImpl implements ApplicationService {
         User user = userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.LOGIN_ERROR_ID));
 
         Event event = eventRepository.findById(eventId).orElseThrow(() -> new TempHandler(ErrorStatus.PRODUCT_ERROR_EVENT));
+
 
         Long productId = event.getProduct().getId();
         Product product = productRepository.findById(productId).orElseThrow(() -> new TempHandler(ErrorStatus.PRODUCT_ERROR_EVENT));
@@ -57,7 +56,9 @@ public class ApplicationServiceImpl implements ApplicationService {
         int reqTickets = product.getReqTickets();
 
         boolean apply = userTickets >= reqTickets;
-
+        if(investmentRepository.findByUserIdAndEventIdAndApply(userId, eventId,apply) != null){
+            throw new TempHandler(ErrorStatus.EVENT_USER_EXIST);
+        }
 
         if (apply) {
             // 변경된 ticket 객체를 저장소에 저장


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#87 
## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
이미 체험 신청한 시제품을 중복 신청 가능했음
--> investment 테이블에 eventId와 userId와 apply=true인 필드값이 존재한다면 EVENT4001 "이미 체험 신청한 시제품입니다." 에러 처리함.
## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 처음 체험 신청하는 경우
![image](https://github.com/user-attachments/assets/5e8cc2cc-9137-4664-8b86-15bfa74f17e8)
2. 중복 신청하는 경우-> 에러 처리
![image](https://github.com/user-attachments/assets/711321e4-8a60-49ee-ad49-72dc3e585752)

