### PR TITLE
[Bug] 최근 검색어 10개 이상 저장 에러 해결

### DIFF
--- a/src/main/java/com/prototyne/service/ProductService/EventServiceImpl.java
+++ b/src/main/java/com/prototyne/service/ProductService/EventServiceImpl.java
@@ -121,7 +121,7 @@ public class EventServiceImpl implements EventService {
         recentSearchList.add(0, searchTerm);
 
         if(recentSearchList.size() > 10){
-            recentSearchList.remove(recentSearchList.size());
+            recentSearchList.remove(recentSearchList.size()-1);
         }
         userRepository.save(user);
     }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #92 

## ✨ PR 내용
<!-- PR에 대한 설명을 적어주세요 -->
- 유저가 검색 10번 이상 했을 때, 최근 검색어 목록에 저장되지 않고 500 에러 발생하는 현상 해결
- [x] 인덱스 참조값 변경
- `기존: recentSearchList.size() ▶ 변경: recentSearchList.size()-1`

## 📚 레퍼런스 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### `POST /search` 로 검색 동시에 최근 검색어 목록에 저장
![post검색어](https://github.com/user-attachments/assets/5a54612b-efb1-4fe0-b882-8604ab032679)

### `GET /search/recent` 로 최근 검색어 목록 조회 시, 10개가 넘어가더라도 가장 오래된 검색어를 삭제하고 최근 검색어를 제대로 반영하는 것을 확인
![get검색어](https://github.com/user-attachments/assets/9cd91df8-d324-4f92-8185-6af1977b1f37)

